### PR TITLE
Fixes to zoom variable persistence

### DIFF
--- a/zoom/config.json
+++ b/zoom/config.json
@@ -1,0 +1,6 @@
+{
+   "overview_zoom": 1.0,
+   "overview_zoom_default": 1.0,
+   "review_zoom": 1.0,
+   "review_zoom_default": 1.0
+}


### PR DESCRIPTION
Changed the state trigger listener event
State change now triggers zoom to set to currently configured level
Zoom variable are now stored in the external configuration
Simplified the variables needed for different states